### PR TITLE
Return error msg instead of raising it

### DIFF
--- a/scrapy/http/request/__init__.py
+++ b/scrapy/http/request/__init__.py
@@ -245,4 +245,4 @@ def _find_method(obj, func):
             # https://docs.python.org/3/reference/datamodel.html
             if obj_func.__func__ is func.__func__:
                 return name
-    raise ValueError(f"Function {func} is not an instance method in: {obj}")
+    return f"Function {func} is not an instance method in: {obj}"


### PR DESCRIPTION
`Request.to_dict()` crashes when functions like errback, or callback are not instance methods. This is only needed when using this logic to serialise, and deserialise. This logic is very fragile, and the requirement that a function is an instance method is not really needed. 

Long term this should be fixed by using a better serialise/deserialise approach, but since we only use this function to log extra info, this is not a requirement right. The new logic will just save the error string instead of raising it and crashing the entire operation. If this is used for deserialising it will still raise Errors (so we just shift the error origin from serialise to deserialise).

Place that use/need the original logic, but that we currently don't use: (this also doesn't work with our current code)
```
PickleFifoDiskQueue = _scrapy_serialization_queue(_PickleFifoSerializationDiskQueue)
PickleLifoDiskQueue = _scrapy_serialization_queue(_PickleLifoSerializationDiskQueue)
MarshalFifoDiskQueue = _scrapy_serialization_queue(_MarshalFifoSerializationDiskQueue)
MarshalLifoDiskQueue = _scrapy_serialization_queue(_MarshalLifoSerializationDiskQueue)
```