### PR TITLE
Support otlp metrics in scrapy crawler

### DIFF
--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -23,6 +23,7 @@ from scrapy.exceptions import ScrapyDeprecationWarning
 from scrapy.extension import ExtensionManager
 from scrapy.interfaces import ISpiderLoader
 from scrapy.logformatter import LogFormatter
+from scrapy.meter_providers import MeterProvider
 from scrapy.settings import Settings, overridden_settings
 from scrapy.signalmanager import SignalManager
 from scrapy.statscollectors import StatsCollector
@@ -118,6 +119,12 @@ class Crawler:
         self.crawling: bool = False
         self.spider: Optional[Spider] = None
         self.engine: Optional[ExecutionEngine] = None
+
+    def labels(self, *args, **kwargs):
+        spider_labels = self.spider.labels(*args, **kwargs) if self.spider else {}
+        return {
+            **spider_labels
+        }
 
     @defer.inlineCallbacks
     def crawl(self, *args, **kwargs):

--- a/scrapy/crawler.py
+++ b/scrapy/crawler.py
@@ -70,6 +70,7 @@ class Crawler:
         self.signals: SignalManager = SignalManager(self)
 
         self.stats: StatsCollector = load_object(self.settings["STATS_CLASS"])(self)
+        self.meter_provider: MeterProvider = load_object(self.settings["METER_PROVIDER_CLASS"])(self)
 
         handler = LogCounterHandler(self, level=self.settings.get("LOG_LEVEL"))
         logging.root.addHandler(handler)

--- a/scrapy/meter_providers.py
+++ b/scrapy/meter_providers.py
@@ -3,7 +3,7 @@ Scrapy extension for collecting otlp metrics
 """
 from abc import ABC, abstractmethod
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from opentelemetry.metrics import NoOpMeterProvider, MeterProvider
 
@@ -23,9 +23,9 @@ class MeterProvider(MeterProvider, ABC):
         Use crawler to configure the Meter Provider
         """
 
-class NoOpMeterProvider(NoOpMeterProvider):
+class NoOpMeterProvider(NoOpMeterProvider, MeterProvider):
     """
     Wrapper for NoOpMeterProvider so we support passing crawler during init.
     """
-    def __init__(self, crawler: "Crawler"):
-        super().__init__()
+    def __init__(self, crawler: "Optional[Crawler]" = None):
+        super(NoOpMeterProvider).__init__()

--- a/scrapy/meter_providers.py
+++ b/scrapy/meter_providers.py
@@ -1,0 +1,31 @@
+"""
+Scrapy extension for collecting otlp metrics
+"""
+from abc import ABC, abstractmethod
+import logging
+from typing import TYPE_CHECKING
+
+from opentelemetry.metrics import NoOpMeterProvider, MeterProvider
+
+if TYPE_CHECKING:
+    from scrapy.crawler import Crawler
+
+logger = logging.getLogger(__name__)
+
+
+class MeterProvider(MeterProvider, ABC):
+    """
+    Wrapper for MeterProvider so we have crawler available during init.
+    """
+    @abstractmethod
+    def __init__(self, crawler: "Crawler"):
+        """
+        Use crawler to configure the Meter Provider
+        """
+
+class NoOpMeterProvider(NoOpMeterProvider):
+    """
+    Wrapper for NoOpMeterProvider so we support passing crawler during init.
+    """
+    def __init__(self, crawler: "Crawler"):
+        super().__init__()

--- a/scrapy/settings/default_settings.py
+++ b/scrapy/settings/default_settings.py
@@ -287,6 +287,7 @@ SPIDER_MIDDLEWARES_BASE = {
 
 SPIDER_MODULES = []
 
+METER_PROVIDER_CLASS = "scrapy.meter_providers.NoOpMeterProvider"
 STATS_CLASS = "scrapy.statscollectors.MemoryStatsCollector"
 STATS_DUMP = True
 

--- a/scrapy/spiders/__init__.py
+++ b/scrapy/spiders/__init__.py
@@ -39,6 +39,11 @@ class Spider(object_ref):
         logger = logging.getLogger(self.name)
         return logging.LoggerAdapter(logger, {"spider": self})
 
+    def labels(self, *args, **kwargs):
+        return {
+            'spider': self.name,
+        }
+
     def log(self, message, level=logging.DEBUG, **kw):
         """Log the given message at the given log level
 

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ install_requires = [
     "setuptools",
     "packaging",
     "tldextract",
+    "opentelemetry-api",
     "lxml>=4.3.0",
 ]
 extras_require = {}


### PR DESCRIPTION
Support using OTLP metrics in scrapy:
- Expose, and initialise `MeterProvider` in `crawler.meter_provider`
- `MeterProvider` class is configured with `settings["METER_PROVIDER_CLASS"]`
- `MeterProvider` can use crawler instance during `__init__` to configure itself, example:
```python
# meter_providers.py
from opentelemetry.exporter.prometheus import PrometheusMetricReader
from opentelemetry.sdk.metrics import MeterProvider
from prometheus_client import start_http_server
from scrapy.crawler import Crawler

class PrometheusMeterProvider(MeterProvider):
    def __init__(self, crawler: Crawler):
        # TODO proper setting names
        start_http_server(port=crawler.settings.get('prom-port'), addr=crawler.settings.get('prom-addr'))
        prom_reader = PrometheusMetricReader()
        super().__init__(metric_readers=[prom_reader])

# settings.py
Setting.METER_PROVIDER_CLASS: "meter_providers.PrometheusMeterProvider",
```
- Expose basic/default label function on crawler, and spider object
  - Spiders can overwrite/extend this logic to get sensible/default labels everywhere
  - Crawler.labels can be extended to expose more then only spider.labels
  - Pass `*args, **kwargs` so this logic can be extended as much as wanted (ex: when usefull pass request so spider can add used proxy to labels)