### PR TITLE
Engine backout if spider backout

### DIFF
--- a/scrapy/core/engine.py
+++ b/scrapy/core/engine.py
@@ -202,11 +202,13 @@ class ExecutionEngine:
     def _needs_backout(self) -> bool:
         assert self.slot is not None  # typing
         assert self.scraper.slot is not None  # typing
+        assert self.spider is not None  # typing
         return (
             not self.running
             or bool(self.slot.closing)
             or self.downloader.needs_backout()
             or self.scraper.slot.needs_backout()
+            or self.spider.needs_backout()
         )
 
     def _next_request_from_scheduler(self) -> Optional[Deferred]:

--- a/scrapy/spiders/__init__.py
+++ b/scrapy/spiders/__init__.py
@@ -82,6 +82,9 @@ class Spider(object_ref):
             f"{self.__class__.__name__}.parse callback is not defined"
         )
 
+    def needs_backout(self) -> bool:
+        return False
+
     @classmethod
     def update_settings(cls, settings):
         settings.setdict(cls.custom_settings or {}, priority="spider")


### PR DESCRIPTION
Allow spider to signal to engine that it needs backout.  
Engine does backout in some cases, most notable ones are:
- Backout if downloader concurrency is too high
- Backout if parser has too much responses left it has too handle (by response size)

Allowing spider to signal backout, will allow crawlers to also support other cases where backout is needed, eg:
- Don't start new requests if receiving lots of 421
  - Scheduler could schedule requests for later, but for input sources with infinite capacity, this would drain them, something not always wanted
- Sleep the engine without actually freezing everything